### PR TITLE
study-app-ingress: allow to access the app without a trailing '/'

### DIFF
--- a/k8s/base/study-app-ingress.yaml
+++ b/k8s/base/study-app-ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     # but latest minikube 1.1.0 uses V0.23 (untested):
     # nginx.ingress.kubernetes.io/x-forwarded-prefix: "/study-app"
     nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/study-app$ /study-app/ permanent;
       proxy_set_header X-Forwarded-Prefix         /study-app/;
 spec:
   rules:


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
accessing the app at HOST/study-app shows a white screen.

**What is the new behavior (if this is a feature change)?**
accessing the app at HOST/study-app redirects to HOST/study-app/ where the app works



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
